### PR TITLE
Add missing buildtool_depend on git

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>git</buildtool_depend>
 
   <depend>pybind11_vendor</depend>
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

This vendor package uses `git` to fetch the `pybind11_json` sources during the package build. It should declare a dependency on that tool.

### Fix applied

`git` was added to the list of buildtool dependencies for this package.