### PR TITLE
Add missing dependency on nlohmann::json.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>nlohmann-json-dev</depend>
   <depend>pybind11_vendor</depend>
 
   <export>


### PR DESCRIPTION


## Bug fix

### Fixed bug

nlohmann::json is listed as a dependency of pybind11_json[1] and
building the vendor package on the build farm fails during CMake
configuration since it is unable to find the package:

    CMake Error at CMakeLists.txt:29 (find_package):
      By not providing "Findnlohmann_json.cmake" in CMAKE_MODULE_PATH this
      project has asked CMake to find a package configuration file provided by
      "nlohmann_json", but CMake did not find one.

      Could not find a package configuration file provided by "nlohmann_json"
      (requested version 3.2.0) with any of the following names:

        nlohmann_jsonConfig.cmake
        nlohmann_json-config.cmake

      Add the installation prefix of "nlohmann_json" to CMAKE_PREFIX_PATH or set
      "nlohmann_json_DIR" to a directory containing one of the above files.  If
      "nlohmann_json" provides a separate development package or SDK, be sure it
      has been installed.

[1]: https://github.com/pybind/pybind11_json#dependencies

### Fix applied

Declare dependency on nlohmann-json-vendor.
