### PR TITLE
Suppress CMake external project 'update' phase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,13 @@ if(NOT pybind11_json_FOUND)
   set(setup_install_dir "${CMAKE_CURRENT_BINARY_DIR}/pybind11_json")
 
   include(ExternalProject)
-  ExternalProject_Add(pybind11_json
+  set(pybind11_json_version 0fbbe3bbb27bd07a5ec7d71cbb1f17eaf4d37702)
+  ExternalProject_Add(pybind11_json-${pybind11_json_version}
     GIT_REPOSITORY https://github.com/pybind/pybind11_json.git
-    GIT_TAG 0.2.11
+    GIT_TAG ${pybind11_json_version}
+    GIT_CONFIG advice.detachedHead=false
+    # Suppress git update due to https://gitlab.kitware.com/cmake/cmake/-/issues/16419
+    UPDATE_COMMAND ""
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${setup_install_dir}
       -DBUILD_SHARED_LIBS=true


### PR DESCRIPTION
## Bug fix

### Fixed bug

When the 'install' target is invoked during the Debian and RPM package builds, the external project target is re-evaluated to determine if it is stale. By default, CMake performs an 'update' command on the source repository, which invalidates the target and causes the external project to be re-built.

This is a problem because when the 'install' target is invoked by the Debian/RPM build, the 'DESTDIR' variable is passed, which makes its way into the external project as well. This interferes with the sub-project's installation into the build directory, and results in unexpected files getting installed into the platform package staging directory.

This is a problem for both Debian and RPM builds, but it is only a fatal error in RPM builds at the moment.

### Fix applied

Using a ref which can never change and suppressing the 'update' phase of the external project is enough to ensure that the external project is not deemed 'stale' during the install target invocation, and avoids the problem.