### PR TITLE
Support vendor-provided pybind11 upstream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ endif()
 
 
 if(NOT pybind11_json_FOUND)
+  find_package(pybind11_vendor REQUIRED)
+  find_package(pybind11 REQUIRED)
 
   set(setup_install_dir "${CMAKE_CURRENT_BINARY_DIR}/pybind11_json")
 
@@ -29,6 +31,7 @@ if(NOT pybind11_json_FOUND)
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${setup_install_dir}
       -DBUILD_SHARED_LIBS=true
+      -Dpybind11_DIR=${pybind11_DIR}
     INSTALL_DIR ${setup_install_dir}
   )  
 


### PR DESCRIPTION
This vendor package depends on the pybind11_vendor package. That package will conditionally build pybind11 from source if needed. A package downstream of a vendor package usually needs to `find_package` the upstream vendor package for the vendored payload to be discoverable by CMake.

Since this package itself is a vendor package, the way we can accomplish this is to find_package pybind11 on the vendored package's behalf and specifically tell it where to look.