### PR TITLE
Bump main to 0.4.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package pybind11_json_vendor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.4.1 (2023-08-10)
+------------------
 * Switch to ament_cmake_vendor_package (`#11 <https://github.com/open-rmf/pybind11_json_vendor/pull/11>`_)
 * Contributors: Scott K Logan
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package pybind11_json_vendor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Switch to ament_cmake_vendor_package (`#11 <https://github.com/open-rmf/pybind11_json_vendor/pull/11>`_)
+* Contributors: Scott K Logan
+
 0.4.0 (2023-06-08)
 ------------------
 
@@ -9,7 +14,7 @@ Changelog for package pybind11_json_vendor
 ------------------
 * Switch to rst changelogs
 * Update maintainer
-* Add initial build workflow (`#9 <https://github.com/open-rmf/pybind11_json_vendor/issues/9>`_)
+* Add initial build workflow (`#9 <https://github.com/open-rmf/pybind11_json_vendor/pull/9>`_)
 * Contributors: Esteban Martinena, Yadunund
 
 0.2.2 (2022-12-07)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>pybind11_json_vendor</name>
-  <version>0.4.0</version>
+  <version>0.4.1</version>
   <description>A vendor package for pybind11_json for Modern C++</description>
   <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
Once this is merged, I will tag `main` as `0.4.1` and bloom a release into Rolling.