### PR TITLE
Un-archive repo for Lyrical

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(pybind11_json QUIET)
 ament_vendor(pybind11_json_vendor
   SATISFIED ${pybind11_json_FOUND}
   VCS_URL https://github.com/pybind/pybind11_json.git
-  VCS_VERSION 0.2.11
+  VCS_VERSION 0.2.15
 )
 
 ament_package()

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 > [!WARNING]
-> As described in [#16](https://github.com/open-rmf/pybind11_json_vendor/issues/16) this repo should no longer be needed. You can use the [`pybind11-json-dev`](https://github.com/ros/rosdistro/pull/40223/files) key in rosdep instead.
->
-> Therefore this repo is archived and will not be undergoing any more updates or releases.
+> [A packaging problem upstream in Ubuntu Resolute](https://openrobotics.zulipchat.com/#narrow/channel/526042-Infrastructure-General/topic/Conflicting.20version.20of.20nlohmann-json.20in.20Resolute/with/593414087) has made it necessary to un-archive this package.
 
 # A vendor package for `pybind11_json`
 


### PR DESCRIPTION
This repo needs to be un-archived due to a [dependency problem](https://openrobotics.zulipchat.com/#narrow/channel/526042-Infrastructure-General/topic/Conflicting.20version.20of.20nlohmann-json.20in.20Resolute/with/593414087) in Ubuntu Resolute.

This PR changes the README comment to explain why this repo is active again.

This PR also updates the version of `pybind11_json` that's being used because version 0.2.11 expects cmake version 3.4, which is below the minimum version supported in Ubuntu Resolute.